### PR TITLE
Fixed visible cursor in terminal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -78,11 +78,8 @@ fn app_view(frame: &mut TerminalFrame, app: &App) {
 /// Handle cursor when typing
 fn handle_input_cursor(app: &App, frame: &mut TerminalFrame, chunks: &[Rect]) {
     match app.input_mode {
-        InputMode::Normal =>
         // Hide the cursor. `Frame` does this by default, so we don't need to do anything here
-        {
-            frame.set_cursor(frame.size().x, frame.size().y)
-        }
+        InputMode::Normal => (),
         InputMode::Editing => {
             // Make the cursor visible and ask tui-rs to put it at the specified coordinates after rendering
             frame.set_cursor(


### PR DESCRIPTION
### Description
This commit fixes a bug showing the cursor in Normal mode
with no longer calling the set_cursor function on render.
The cursor doesn't show up anymore. This fixes bug #12.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing: `cargo test`
- [x] Extended the README / documentation, if necessary
- [x] Code is formatted properly with rustfmt: `cargo fmt`
- [x] Run `clippy` (would help a lot to catch possible issues): `cargo clippy` 
